### PR TITLE
use cmake min version env

### DIFF
--- a/.github/workflows/win64_dolphin.yml
+++ b/.github/workflows/win64_dolphin.yml
@@ -19,7 +19,7 @@ jobs:
       run: git clone https://github.com/jonian/libretro-dolphin.git && cd libretro-dolphin && git submodule update --init
     - name: Build libretro dolphin core
       working-directory: libretro-dolphin
-      run: mkdir build && cd build && cmake.exe -DLIBRETRO=ON -DENABLE_QT=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON ..
+      run: mkdir build && cd build && cmake.exe -DLIBRETRO=ON -DENABLE_QT=0 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON ..
 
     - name: Build the thing
       working-directory: libretro-dolphin/build


### PR DESCRIPTION
It seems "Compatibility with CMake < 3.5 has been removed from CMake" and the solution is to add -DCMAKE_POLICY_VERSION_MINIMUM=3.5